### PR TITLE
Add "HAVE_GETNAMEINFO"

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETNAMEINFO.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETNAMEINFO.h
@@ -1,0 +1,19 @@
+// HAVE_GETNAMEINFO : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETNAMEINFO
+
+/* Since Linux/glibc 2.1, OpenBSD 2.9, FreeBSD 4.0, NetBSD 1.5, and Mac OS X 
+ * (hard to tell but based on the manpages available online it looks like 
+ * Tiger at the latest).
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 1) || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(4, 0)|| \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(200106) || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 5) || \
+    defined(BUILD2_AUTOCONF_MACOS)
+#  define HAVE_GETNAMEINFO 1
+#endif


### PR DESCRIPTION
As help was requested in #1, I grabbed getnameinfo to understand what work needed to be done.
I followed the structure used in `HAVE_EVENTFD`. If this is the correct format Ill continue adding more.

Note: I could not find which version it was introduced in MACOS so I ignored it and added a comment, please feel free to share if you can find which version introduced it.