### PR TITLE
Add "HAVE_GETRANDOM"

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETRANDOM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETRANDOM.h
@@ -1,0 +1,14 @@
+// HAVE_GETRANDOM : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETRANDOM
+
+/* Since FreeBSD 12.0 and glibc 2.25.
+ */
+#if BUILD2_AUTOCONF_FREEBSD_PREREQ(12, 0)  || \
+    BUILD2_AUTOCONF_GLIBC_PREREQ(2, 25)
+#  define HAVE_GETRANDOM 1
+#endif


### PR DESCRIPTION
#1 

* https://man7.org/linux/man-pages/man2/getrandom.2.html
    > Support was added to glibc in version 2.25.
* https://www.freebsd.org/cgi/man.cgi?query=getrandom&apropos=0&sektion=2&manpath=FreeBSD+12.0-RELEASE&arch=default&format=html
    > The getrandom() system call first appeared	in FreeBSD 12.0.