### PR TITLE
Add "HAVE_NETDB_H"

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_NETDB_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_NETDB_H.h
@@ -1,0 +1,16 @@
+// HAVE_NETDB_H : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_NETDB_H
+
+/* Since BSD 4.2 (1983) */
+#if defined(__FreeBSD__)            || \
+    defined(__OpenBSD__)            || \
+    defined(__NetBSD__)             || \
+    defined(__GLIBC__)              || \
+    defined(BUILD2_AUTOCONF_MACOS)
+#  define HAVE_NETDB_H 1
+#endif


### PR DESCRIPTION
#1 

* https://www.freebsd.org/cgi/man.cgi?query=getnetent&apropos=0&sektion=3&manpath=FreeBSD+14.0-current&arch=default&format=html
    > The getnetent(), getnetbyaddr(), getnetbyname(), setnetent(), and endnetent() functions appeared in 4.2BSD.
    (and these are in `netdb.h`)