### PR TITLE
Add "HAVE_FCNTL"

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FCNTL.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FCNTL.h
@@ -1,0 +1,16 @@
+// HAVE_FCNTL : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_FCNTL
+/* Since BSD 4.2 (1983)
+ */
+#if defined(__linux__)   || \
+    defined(__FreeBSD__) || \
+    defined(__OpenBSD__) || \
+    defined(__NetBSD__)  || \
+    defined(BUILD2_AUTOCONF_MACOS)
+#  define HAVE_FCNTL 1
+#endif


### PR DESCRIPTION
#1

https://www.freebsd.org/cgi/man.cgi?query=fcntl&apropos=0&sektion=0&manpath=FreeBSD+13.1-RELEASE+and+Ports&arch=default&format=html
> The fcntl() system	call appeared in 4.2BSD.