### PR TITLE
add timerfd_create

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_TIMERFD_CREATE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_TIMERFD_CREATE.h
@@ -1,0 +1,14 @@
+// HAVE_TIMERFD_CREATE : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_TIMERFD_CREATE
+
+/* Since Linux/glibc 2.8 and Mac OS
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 8) || \
+    defined(BUILD2_AUTOCONF_MACOS)
+#  define HAVE_TIMERFD_CREATE 1
+#endif


### PR DESCRIPTION
### add timerfd_create
#1 
https://www.gnu.org/software/gnulib/manual/html_node/timerfd_005fcreate.html
> This function exists only on Linux and illumos and is therefore missing on many non-glibc platforms: glibc 2.7, macOS 11.1, FreeBSD 13.0, NetBSD 9.0, OpenBSD 6.7, Minix 3.1.8, AIX 7.1, HP-UX 11.31, IRIX 6.5, Solaris 11.4, Cygwin 2.9, mingw, MSVC 14, Android 4.3.