### PR TITLE
add __func__ and __FUNCTION__

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___FUNCTION__.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___FUNCTION__.h
@@ -1,0 +1,10 @@
+// HAVE___FUNCTION__
+
+#undef HAVE___FUNCTION__
+
+/* HAVE___FUNCTION__
+ * __FUNCTION__ is another name for __func__, provided for backward
+ * compatibility with old versions of GCC.
+ * Although it is seemingly available everywhere else.
+ */
+#define HAVE___FUNCTION__ 1

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___func__.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___func__.h
@@ -3,8 +3,8 @@
 #undef HAVE___func__
 
 /* HAVE___func__
- * __func__ was added to the standard in C++11.
+ * __func__ was added to the standard in C++11. But seemingly exists 
+ * almost everywhere before that as well.
  */
-#if (defined(__cplusplus) && __cplusplus >= 201103L) || defined(_MSVC_LANG) && (_MSVC_LANG >= 1900)
-#   define HAVE___func__ 1
-#endif
+
+#define HAVE___func__ 1

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___func__.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___func__.h
@@ -1,0 +1,10 @@
+// HAVE___func__
+
+#undef HAVE___func__
+
+/* HAVE___func__
+ * __func__ was added to the standard in C++11.
+ */
+#if (defined(__cplusplus) && __cplusplus >= 201103L) || defined(_MSVC_LANG) && (_MSVC_LANG >= 1900)
+#   define HAVE___func__ 1
+#endif


### PR DESCRIPTION
### add __func__ and __FUNCTION__
#1 
These two seem to be defined everywhere but I can't anything specifying where its guaranteed. The `__func__` seems to be standardised in c++11 https://stackoverflow.com/a/4384825. While __FUNCTION__ seem to be older and I can't find any info on when or where its specified. 

@boris-kolpackov I think you have to decide what todo with these.