### PR TITLE
Add gethostbyname_r versions

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R.h
@@ -1,0 +1,16 @@
+// HAVE_GETHOSTBYNAME_R : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETHOSTBYNAME_R
+
+/* Since Linux/glibc 2.1, SunOS, AIX and HPUX. 
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 1)       || \
+    defined(__SunOS) && defined(__SunOS_5_5) || \   
+    defined(_AIX) || \ 
+    defined(__hpux)  
+#  define HAVE_GETHOSTBYNAME_R 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_3_ARG.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_3_ARG.h
@@ -1,0 +1,13 @@
+// HAVE_GETHOSTBYNAME_R_3_ARG : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETHOSTBYNAME_R_3_ARG
+
+/* AIX4, HPUX 10 uses 3 args
+ */
+#if defined(_AIX) || defined(__hpux)
+#  define HAVE_GETHOSTBYNAME_R_3_ARG 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_5_ARG.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_5_ARG.h
@@ -1,0 +1,13 @@
+// HAVE_GETHOSTBYNAME_R_5_ARG : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETHOSTBYNAME_R_5_ARG
+
+/* Solaris uses 5 args starting from at latest 5.5 could not find earlier.
+ */
+#if defined(__SunOS) && defined(__SunOS_5_5)
+#  define HAVE_GETHOSTBYNAME_R_5_ARG 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_6_ARG.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_GETHOSTBYNAME_R_6_ARG.h
@@ -1,0 +1,13 @@
+// HAVE_GETHOSTBYNAME_R_6_ARG : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_GETHOSTBYNAME_R_6_ARG
+
+/* Since Linux/glibc 2.1
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 1)
+#  define HAVE_GETHOSTBYNAME_R_6_ARG 1
+#endif


### PR DESCRIPTION
### Add gethostbyname_r versions
#1 

https://daniel.haxx.se/projects/portability/
> AIX4, Digital Unix/Tru64, HPUX 10 use 3 arguments: int gethostbyname_r(char *hostname, struct hostent *hostent, struct hostent_data *data)
> 
> Solaris (needs to be linked with -lnsl) and IRIX use 5 arguments: int gethostbyname_r(char *hostname, struct hostent *hostent, char *buffer, int buflen, int *h_errnop)
> 
> Linux uses 6 arguments: int gethostbyname_r(const char *name, struct hostent *ret, char *buf, size_t buflen, struct hostent **result, int *h_errnop)