### PR TITLE
Add SIZEOF_OFF_T.H

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_OFF_T.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_OFF_T.h
@@ -4,7 +4,7 @@
 
 #ifdef _MSC_VER
 #  define SIZEOF_OFF_T 4
-#elif __x86_64__ || __ppc64__ || _FILE_OFFSET_BITS == 64
+#elif defined(__x86_64__) || defined(__ppc64__) || (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64)
 #  define SIZEOF_OFF_T 8
 #else
 #  define SIZEOF_OFF_T 4

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_OFF_T.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_OFF_T.h
@@ -1,0 +1,11 @@
+// SIZEOF_OFF_T
+
+#undef SIZEOF_OFF_T
+
+#ifdef _MSC_VER
+#  define SIZEOF_OFF_T 4
+#elif __x86_64__ || __ppc64__ || _FILE_OFFSET_BITS == 64
+#  define SIZEOF_OFF_T 8
+#else
+#  define SIZEOF_OFF_T 4
+#endif


### PR DESCRIPTION
### Add SIZEOF_OFF_T.H
#1 
Posix
> This is a data type defined in the sys/types.h header file (of fundamental type unsigned long) and is used to measure the file offset in bytes from the beginning of the file. It is defined as a signed, 32-bit integer, but if the programming environment enables large files off_t is defined to be a signed, 64-bit integer.

Always `4` on windows