### PR TITLE
Add stddef and stdarg

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_STDARG_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_STDARG_H.h
@@ -1,0 +1,5 @@
+// HAVE_STDARG_H
+
+#undef HAVE_STDARG_H
+
+#define HAVE_STDARG_H 1

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_STDDEF_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_STDDEF_H.h
@@ -1,0 +1,5 @@
+// HAVE_STDLIB_H
+
+#undef HAVE_STDLIB_H
+
+#define HAVE_STDLIB_H 1


### PR DESCRIPTION
### Add stddef and stdarg
#1 
The following does not specify that its missing on any platforms, so I just defined it to 1.
https://www.gnu.org/software/gnulib/manual/html_node/stdarg_002eh.html
https://www.gnu.org/software/gnulib/manual/html_node/stddef_002eh.html