### PR TITLE
Add AFUNIX_H

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AFUNIX_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AFUNIX_H.h
@@ -1,4 +1,7 @@
 // HAVE_AFUNIX_H
+
+#undef HAVE_AFUNIX_H
+
 #ifdef _MSC_VER
 #include <sdkddkver.h>
 #endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AFUNIX_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AFUNIX_H.h
@@ -1,0 +1,11 @@
+// HAVE_AFUNIX_H
+#ifdef _MSC_VER
+#include <sdkddkver.h>
+#endif
+
+#if defined(__MINGW32__) && __MINGW32_MAJOR_VERSION >= 11 || \
+    defined(__MINGW64__) && __MINGW64_VERSION_MAJOR >= 11 || \
+    defined(_MSC_VER) && defined(WDK_NTDDI_VERSION) && \
+    WDK_NTDDI_VERSION >= NTDDI_WIN10_19H1
+#define HAVE_AFUNIX_H 1
+#endif


### PR DESCRIPTION
### Add AFUNIX_H
#1 

The afunix.h header exists in NTDDI_WIN10_19H1 but possibly even earlier.
According to @boris-kolpackov we go by MINGW major 11.