### PR TITLE
Use sizeof ptr as size of pthread_t

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_PTHREAD_T.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/SIZEOF_PTHREAD_T.h
@@ -2,14 +2,12 @@
 
 #undef SIZEOF_PTHREAD_T
 
-#ifndef _WIN32
-#   if defined(__APPLE__)
-#       ifdef __LP64__
-#           define SIZEOF_PTHREAD_T 8
-#       else
-#           define SIZEOF_PTHREAD_T 4
-#       endif
-#   else
-#       define SIZEOF_PTHREAD_T 4
-#   endif
+#ifndef _MSC_VER
+#  ifdef __SIZEOF_POINTER__
+#    define SIZEOF_PTHREAD_T __SIZEOF_POINTER__
+#  endif
+
+#  ifndef SIZEOF_PTHREAD_T
+#    error unable to determine size of pthread_t
+#  endif
 #endif


### PR DESCRIPTION
Brought up in issue #47, The SIZEOF_PTHREAD_T was incorrectly implemented.
---
@boris-kolpackov I have now implemented it to match `__SIZEOF_POINTER__`. This seems to work https://ci.stage.build2.org/@735d596c-f9a6-47df-ae4b-4a55f3ed9e85.
