### PR TITLE
HAVE_SYS_POLL_H: Define on MacOS, FreeBSD, NetBSD & OpenBSD

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SYS_POLL_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SYS_POLL_H.h
@@ -6,9 +6,14 @@
 
 #undef HAVE_SYS_POLL_H
 
-/* All use poll.h: FreeBSD, OpenBSD, NetBSD, Mac OS.
- * Since glibc 2.0.
+/* Since glibc 2.0.
+ * FreeBSD, OpenBSD, NetBSD, Mac OS: 
+ * All use poll.h though sys/poll.h still exists.
  */
-#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 0)
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 0) || \
+    defined(__FreeBSD__)               || \
+    defined(__OpenBSD__)               || \
+    defined(__NetBSD__)                || \
+    defined(BUILD2_AUTOCONF_MACOS)
 #  define HAVE_SYS_POLL_H 1
 #endif


### PR DESCRIPTION
#49 

I verified this on MacOS (was required to build thrift package). Haven't verified any other, though in my builds FreeBSD fails with the [exact same error as MacOS](https://ci.stage.build2.org/@f4f328b5-91a6-4e5b-858b-b1989b0d97ea/libthrift/0.16.0-a.0.20220926122251.f3fb322cbf8d/log/freebsd_13-clang_13.0/x86_64-freebsd13.1/stage/0.16.0-a.0.20220923095809.06beb098c579/update), and some quick googling suggests the `sys/poll.h` header exists on the other BSD derivatives as well.

* https://github.com/lattera/openbsd/blob/master/sys/sys/poll.h
* https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/sys/sys/poll.h