### PR TITLE
`MacOSX14.sdk`: Work around missing include in system headers (GCC)

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/BUILD2_AUTOCONF_LIBC_VERSION.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/BUILD2_AUTOCONF_LIBC_VERSION.h
@@ -113,6 +113,10 @@
  */
 #  include <sys/param.h> /* OpenBSD, __NetBSD_Version__ */
 #elif defined(__APPLE__)
+// Note: In newer versions apple internally use __has_extension & __has_buildin
+//       without including the (required) header <sys/cdefs.h>.
+//       This is specifically a problem with GCC, so lets include it first.
+#  include <sys/cdefs.h>
 #  include <Availability.h> /* __MAC_OS_X_VERSION_MIN_REQUIRED */
 #elif defined(__MINGW32__)
 #  include <_mingw.h> /* __MINGW64_VERSION_{MAJOR,MINOR} */


### PR DESCRIPTION
In a recent update, some of Apple's system headers use `__has_extension` & `__has_builtin` without including the required header. This specifically fails when building with GCC on MacOS.
Work around this by including the header `<sys/cdefs.h>` before `<Availability.h>`.

Example error from the `<Availability.h>` header used by `libbuild2-autoconf`:
```
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/AvailabilityInternal.h:38:48: error: missing binary operator before token "("
   38 |     #if defined(__has_builtin) && __has_builtin(__is_target_os)
```