### PR TITLE
Add checks for various Win32/MingW functions & headers

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_COMMANDLINETOARGVW.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_COMMANDLINETOARGVW.h
@@ -1,0 +1,10 @@
+// HAVE_COMMANDLINETOARGVW
+
+#undef HAVE_COMMANDLINETOARGVW
+
+/* Windows, Mingw
+ */
+#if defined(_WIN32) || \
+    defined(__MINGW32__)
+#  define HAVE_COMMANDLINETOARGVW 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_DIRECT_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_DIRECT_H.h
@@ -1,0 +1,10 @@
+// HAVE_DIRECT_H
+
+#undef HAVE_DIRECT_H
+
+/* Windows, Mingw
+ */
+#if defined(_WIN32) || \
+    defined(__MINGW32__)
+#  define HAVE_DIRECT_H 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MAPVIEWOFFILE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MAPVIEWOFFILE.h
@@ -1,0 +1,10 @@
+// HAVE_MAPVIEWOFFILE
+
+#undef HAVE_MAPVIEWOFFILE
+
+/* Presence of MapViewOfFile() function.
+ * Supported on Windows
+ */
+#if defined(_WIN32)
+#  define HAVE_MAPVIEWOFFILE 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETCONSOLECTRLHANDLER.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETCONSOLECTRLHANDLER.h
@@ -1,0 +1,11 @@
+// HAVE_SETCONSOLECTRLHANDLER
+
+#undef HAVE_SETCONSOLECTRLHANDLER
+
+/* Presence of the SetConsoleCtrlHandler() function, which is specific
+ * to Windows for handling console control events like Ctrl+C.
+ * Windows
+ */
+#if defined(_WIN32)
+#  define HAVE_SETCONSOLECTRLHANDLER 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETCONSOLETEXTATTRIBUTE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETCONSOLETEXTATTRIBUTE.h
@@ -1,0 +1,11 @@
+// HAVE_SETCONSOLETEXTATTRIBUTE
+
+#undef HAVE_SETCONSOLETEXTATTRIBUTE
+
+/* Presence of the SetConsoleTextAttribute() function, which is used
+ * on Windows to change the text color and attributes in the console.
+ * Windows
+ */
+#if defined(_WIN32)
+#  define HAVE_SETCONSOLETEXTATTRIBUTE 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETDLLDIRECTORY.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SETDLLDIRECTORY.h
@@ -1,0 +1,11 @@
+// HAVE_SETDLLDIRECTORY
+
+#undef HAVE_SETDLLDIRECTORY
+
+/* Presence of the SetDllDirectory() function, which sets a
+ * directory to search for DLLs when loading libraries in Windows.
+ * Windows
+ */
+#if defined(_WIN32)
+#  define HAVE_SETDLLDIRECTORY 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINDOWS_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINDOWS_H.h
@@ -1,0 +1,10 @@
+// HAVE_WINDOWS_H
+
+#undef HAVE_WINDOWS_H
+
+/* Windows, Mingw
+ */
+#if defined(_WIN32) || \
+    defined(__MINGW32__)
+#  define HAVE_WINDOWS_H 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINRT.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINRT.h
@@ -1,0 +1,10 @@
+// HAVE_WINRT
+
+#undef HAVE_WINRT
+
+/* Presence of Windows Runtime (WinRT) APIs, used for building
+ * Universal Windows Platform (UWP) applications.
+ */
+#ifdef __cplusplus_winrt
+#  define HAVE_WINRT 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINSOCK2_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_WINSOCK2_H.h
@@ -1,0 +1,10 @@
+// HAVE_WINSOCK2_H
+
+#undef HAVE_WINSOCK2_H
+
+/* Windows, Mingw
+ */
+#if defined(_WIN32) || \
+    defined(__MINGW32__)
+#  define HAVE_WINSOCK2_H 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE__ALIGNED_MALLOC.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE__ALIGNED_MALLOC.h
@@ -1,0 +1,9 @@
+// HAVE__ALIGNED_MALLOC
+
+#undef HAVE__ALIGNED_MALLOC
+
+/* Windows
+ */
+#if defined(_WIN32)
+#  define HAVE__ALIGNED_MALLOC 1
+#endif


### PR DESCRIPTION
Co-author: @francoisk 

These checks are from the [`FFmpeg` project catalog](https://github.com/build2-packaging/FFmpeg/tree/main/libavutil/build/autoconf/checks), currently building on (mainly) Linux/BSD & Windows/Mingw (CI).