### PR TITLE
Add checks for memory access & layout

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_UNALIGNED.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_UNALIGNED.h
@@ -1,0 +1,22 @@
+// HAVE_FAST_UNALIGNED
+
+#undef HAVE_FAST_UNALIGNED
+
+/* Platforms and compilers supporting efficient unaligned memory access.
+ */
+
+/* x86 and x86-64 (Intel and AMD) */
+#if defined(__x86_64__) || defined(__i386__) || \
+           defined(_M_IX86) || defined(_M_X64)
+/* x86 and x86-64 platforms have efficient unaligned memory access */
+#  define HAVE_FAST_UNALIGNED 1
+#elif defined(__ARM_ARCH) && (__ARM_ARCH >= 7) /* ARMv7-A or later */
+/* ARMv7-A and ARMv8-A architectures support fast unaligned access */
+#  define HAVE_FAST_UNALIGNED 1
+#elif defined(__aarch64__)  /* ARM 64-bit (ARMv8) */
+/* ARMv8-A (64-bit) has fast unaligned access */
+#  define HAVE_FAST_UNALIGNED 1
+#elif defined(__POWERPC__) && defined(__ALTIVEC__) /* PowerPC with AltiVec support */
+/* Some PowerPC platforms with AltiVec might support efficient unaligned access */
+#  define HAVE_FAST_UNALIGNED 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOCAL_ALIGNED.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOCAL_ALIGNED.h
@@ -1,0 +1,10 @@
+// HAVE_LOCAL_ALIGNED
+
+#undef HAVE_LOCAL_ALIGNED
+
+/* Platforms and compilers supporting alignment attributes
+ */
+ #if (defined(__SSE__) || defined(__AVX__) || defined(__ARM_NEON__) || defined(__ALTIVEC__)) \
+     && (defined(__GNUC__) || defined(_MSC_VER))
+#  define HAVE_LOCAL_ALIGNED 1
+#endif


### PR DESCRIPTION
Co-author: @francoisk 

These checks are from the [`FFmpeg` project catalog](https://github.com/build2-packaging/FFmpeg/tree/main/libavutil/build/autoconf/checks), currently building on (mainly) Linux/BSD & Windows/Mingw (CI).