### PR TITLE
Add checks for compiler intrinsics

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CHOOSE_EXPR.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CHOOSE_EXPR.h
@@ -1,0 +1,16 @@
+// HAVE___BUILTIN_CHOOSE_EXPR
+
+#undef HAVE___BUILTIN_CHOOSE_EXPR
+
+/* Check for the __builtin_choose_expr() function.
+ * __builtin_choose_expr() is a GCC/Clang intrinsic that selects between two
+ * expressions based on a constant condition at compile time.
+ *
+ * Available on Linux/glibc, MacOS. Not available on Windows including MinGW.
+ * Supported by GCC 3.0 or later and Clang 3.0 or later.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 3)) || \
+     (defined(__clang__) && (__clang_major__ >= 3))) && \
+    !defined(_WIN32)
+#  define HAVE___BUILTIN_CHOOSE_EXPR 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CLZ.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CLZ.h
@@ -1,0 +1,15 @@
+// HAVE___BUILTIN_CLZ
+
+#undef HAVE___BUILTIN_CLZ
+
+/* Check for the __builtin_clz() function.
+ * __builtin_clz() is a GCC/Clang intrinsic that counts the number of leading
+ * zeros in the binary representation of an integer.
+ *
+ * Available on Linux/glibc, MacOS, Windows including MinGW.
+ * Supported by GCC 3.0 or later and Clang 3.0 or later.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 3)) || \
+     (defined(__clang__) && (__clang_major__ >= 3)))
+#  define HAVE___BUILTIN_CLZ 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CONSTANT_P.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_CONSTANT_P.h
@@ -1,0 +1,16 @@
+// HAVE___BUILTIN_CONSTANT_P
+
+#undef HAVE___BUILTIN_CONSTANT_P
+
+/* Check for the __builtin_constant_p() function.
+ * __builtin_constant_p() is a GCC/Clang intrinsic that determines at compile
+ * time if an expression is a constant.
+ *
+ * Available on Linux/glibc, MacOS. Not available on Windows including MinGW.
+ * Supported by GCC 3.0 or later and Clang 1.0 or later.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 3)) || \
+     (defined(__clang__) && (__clang_major__ >= 1))) && \
+    !defined(_WIN32)
+#  define HAVE___BUILTIN_CONSTANT_P 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_EXPECT.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_EXPECT.h
@@ -1,0 +1,14 @@
+// HAVE___BUILTIN_EXPECT
+
+#undef HAVE___BUILTIN_EXPECT
+
+/* Check for the __builtin_expect() function.
+ * __builtin_expect() is a GCC/Clang intrinsic that provides branch prediction
+ * hints to optimize performance.
+ *
+ * Available on Linux/glibc, MacOS, Windows including MinGW.
+ * Supported by GCC and Clang 3.0 or later.
+ */
+#if defined(__GNUC__) || (defined(__clang__) && (__clang_major__ >= 3))
+#  define HAVE___BUILTIN_EXPECT 1
+#endif


### PR DESCRIPTION
Co-author: @francoisk 

These checks are from the [`FFmpeg` project catalog](https://github.com/build2-packaging/FFmpeg/tree/main/libavutil/build/autoconf/checks) as well as from [`NASM`](https://github.com/build2-packaging/nasm/tree/main/nasm/build/autoconf/checks), currently building on (mainly) Linux/BSD & Windows/Mingw (CI).