### PR TITLE
Add checks for endianness macros/intrinsics

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_16.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_16.h
@@ -1,0 +1,17 @@
+// HAVE___BSWAP_16 : BUILD2_AUTOCONF_LIBC_VERSION
+
+#undef HAVE___BSWAP_16
+
+/* Checks for the availability of the __bswap_16
+ * macro or intrinsic, which swaps the byte order
+ * of a 16-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 9)      || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(5, 0)    || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(200305)  || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 6)
+#  define HAVE___BSWAP_16 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_32.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_32.h
@@ -1,0 +1,17 @@
+// HAVE___BSWAP_32 : BUILD2_AUTOCONF_LIBC_VERSION
+
+#undef HAVE___BSWAP_32
+
+/* Checks for the availability of the __bswap_32
+ * macro or intrinsic, which swaps the byte order
+ * of a 32-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 9)      || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(5, 0)    || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(200305)  || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 6)
+#  define HAVE___BSWAP_32 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_64.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BSWAP_64.h
@@ -1,0 +1,17 @@
+// HAVE___BSWAP_64 : BUILD2_AUTOCONF_LIBC_VERSION
+
+#undef HAVE___BSWAP_64
+
+/* Checks for the availability of the __bswap_64
+ * macro or intrinsic, which swaps the byte order
+ * of a 64-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 9)      || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(5, 0)    || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(200305)  || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 6)
+#  define HAVE___BSWAP_64 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP16.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP16.h
@@ -1,0 +1,16 @@
+// HAVE___BUILTIN_BSWAP16
+
+#undef HAVE___BUILTIN_BSWAP16
+
+/* Checks for the availability of the __builtin_bswap16
+ * macro or intrinsic, which swaps the byte order
+ * of a 64-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 5)) || \
+     (defined(__clang__) && (__clang_major__ >= 3))) && \
+    !defined(_WIN32)
+#  define HAVE___BUILTIN_BSWAP16 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP32.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP32.h
@@ -1,0 +1,16 @@
+// HAVE___BUILTIN_BSWAP32
+
+#undef HAVE___BUILTIN_BSWAP32
+
+/* Checks for the availability of the __builtin_bswap32
+ * macro or intrinsic, which swaps the byte order
+ * of a 32-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 5)) || \
+     (defined(__clang__) && (__clang_major__ >= 3))) && \
+    !defined(_WIN32)
+#  define HAVE___BUILTIN_BSWAP32 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP64.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___BUILTIN_BSWAP64.h
@@ -1,0 +1,16 @@
+// HAVE___BUILTIN_BSWAP64
+
+#undef HAVE___BUILTIN_BSWAP64
+
+/* Checks for the availability of the __builtin_bswap64
+ * macro or intrinsic, which swaps the byte order
+ * of a 64-bit integer.
+ * It is typically defined in system headers such
+ * as <byteswap.h> on GNU-based systems or equivalent
+ * headers on other platforms.
+ */
+#if ((defined(__GNUC__) && (__GNUC__ >= 5)) || \
+     (defined(__clang__) && (__clang_major__ >= 3))) && \
+    !defined(_WIN32)
+#  define HAVE___BUILTIN_BSWAP64 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE16.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE16.h
@@ -1,0 +1,14 @@
+// HAVE___CPU_TO_LE16
+
+#undef HAVE___CPU_TO_LE16
+
+/* These checks verify whether the __cpu_to_le16
+ * macros or intrinsics is available. This macro
+ * convert integers from CPU (host) endianness to
+ * little-endian format.
+ */
+#if (defined(__linux__) && defined(__KERNEL__))     || \
+    (defined(__FreeBSD__) && defined(_KERNEL))   || \
+    defined(__OpenBSD__) || defined(__NetBSD__)
+#  define HAVE___CPU_TO_LE16 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE32.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE32.h
@@ -1,0 +1,14 @@
+// HAVE___CPU_TO_LE32
+
+#undef HAVE___CPU_TO_LE32
+
+/* These checks verify whether the __cpu_to_le32
+ * macros or intrinsics is available. This macro
+ * convert integers from CPU (host) endianness to
+ * little-endian format.
+ */
+#if (defined(__linux__) && defined(__KERNEL__))     || \
+    (defined(__FreeBSD__) && defined(_KERNEL))   || \
+    defined(__OpenBSD__) || defined(__NetBSD__)
+#  define HAVE___CPU_TO_LE32 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE64.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE___CPU_TO_LE64.h
@@ -1,0 +1,14 @@
+// HAVE___CPU_TO_LE64
+
+#undef HAVE___CPU_TO_LE64
+
+/* These checks verify whether the __cpu_to_le64
+ * macros or intrinsics is available. This macro
+ * convert integers from CPU (host) endianness to
+ * little-endian format.
+ */
+#if (defined(__linux__) && defined(__KERNEL__))     || \
+    (defined(__FreeBSD__) && defined(_KERNEL))   || \
+    defined(__OpenBSD__) || defined(__NetBSD__)
+#  define HAVE___CPU_TO_LE64 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/WORDS_LITTLEENDIAN.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/WORDS_LITTLEENDIAN.h
@@ -1,0 +1,11 @@
+// WORDS_LITTLEENDIAN : BYTE_ORDER
+
+#ifndef BYTE_ORDER
+#  error BYTE_ORDER appears to be conditionally included
+#endif
+
+#undef WORDS_LITTLEENDIAN
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#  define WORDS_LITTLEENDIAN 1
+#endif


### PR DESCRIPTION
Co-author: @francoisk 

These checks are from the [`FFmpeg` project catalog](https://github.com/build2-packaging/FFmpeg/tree/main/libavutil/build/autoconf/checks) as well as from [`NASM`](https://github.com/build2-packaging/nasm/tree/main/nasm/build/autoconf/checks), currently building on (mainly) Linux/BSD & Windows/Mingw (CI).