### PR TITLE
Add architecture & assembly checks

### DIFF
--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ALTIVEC.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ALTIVEC.h
@@ -1,0 +1,15 @@
+// HAVE_ALTIVEC
+
+#undef HAVE_ALTIVEC
+
+/* PowerPC (POWER1 and later)
+ */
+#if defined(__powerpc) || \
+    defined(__powerpc__) || \
+    defined(__powerpc64__) || \
+    defined(__POWERPC__) || \
+    defined(__ppc__) || \
+    defined(__PPC__) || \
+    defined(_ARCH_PPC)
+#  define HAVE_ALTIVEC 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ARMASM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ARMASM.h
@@ -1,0 +1,12 @@
+// HAVE_ARMASM
+
+#undef HAVE_ARMASM
+
+// Check for ARM assembly support based on compiler targeting ARM
+
+// GCC or Clang (including Apple Clang) - Check for ARM target architecture
+#if defined(__GNUC__) || defined(__clang__)
+#  if defined(__ARM_ARCH) || defined(__arm__) || defined(__aarch64__)
+#    define HAVE_ARMASM 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ARMV8.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ARMV8.h
@@ -1,0 +1,13 @@
+// HAVE_ARMV8
+
+#undef HAVE_ARMV8
+
+/* Based on:
+ * https://developer.arm.com/documentation/dui0774/g/chr1383660321827
+ * https://developer.arm.com/documentation/101028/0012/5--Feature-test-macros
+ */
+#if defined(__ARM_ARCH)
+#  if __ARM_ARCH == 8
+#    define HAVE_ARMV8 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_EBP.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_EBP.h
@@ -1,0 +1,15 @@
+// HAVE_ASM_EBP
+
+#undef HAVE_ASM_EBP
+
+/* Check for EBP (Extended Base Pointer) support in assembly on x86/x86_64,
+ * excluding unsupported architectures (ARM, PowerPC, MIPS, RISC-V)
+ * and excluding Windows x64 with MSVC due to calling convention limitations.
+ */
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)) && \
+    !(defined(_WIN32) && defined(_MSC_VER) && defined(_M_X64)) && \
+    !defined(__arm__) && !defined(__aarch64__) && \
+    !defined(__powerpc__) && !defined(__ppc__) && \
+    !defined(__mips__) && !defined(__riscv)
+    #define HAVE_ASM_EBP 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_EBX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_EBX.h
@@ -1,0 +1,15 @@
+// HAVE_ASM_EBX
+
+#undef HAVE_ASM_EBX
+
+/* Check for EBX (Extended Base Pointer) support in assembly on x86/x86_64,
+ * excluding unsupported architectures (ARM, PowerPC, MIPS, RISC-V)
+ * and excluding Windows x64 with MSVC due to calling convention limitations.
+ */
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)) && \
+    !(defined(_WIN32) && defined(_MSC_VER) && defined(_M_X64)) && \
+    !defined(__arm__) && !defined(__aarch64__) && \
+    !defined(__powerpc__) && !defined(__ppc__) && \
+    !defined(__mips__) && !defined(__riscv)
+    #define HAVE_ASM_EBX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_TYPES_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ASM_TYPES_H.h
@@ -1,0 +1,9 @@
+// HAVE_ASM_TYPES_H
+
+#undef HAVE_ASM_TYPES_H
+
+/* Since Linux 2.2.
+ */
+#if defined(__linux__)
+#  define HAVE_ASM_TYPES_H 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCHEXT_DOTPROD.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCHEXT_DOTPROD.h
@@ -1,0 +1,10 @@
+// HAVE_AS_ARCHEXT_DOTPROD
+
+#undef HAVE_AS_ARCHEXT_DOTPROD
+
+/* Assembly feature.
+ * Available in Cortex-A75, Cortex-A55, and Neoverse N1 and later.
+ */
+#if defined(__ARM_FEATURE_DOTPROD)
+#  define HAVE_AS_ARCHEXT_DOTPROD 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCHEXT_I8MM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCHEXT_I8MM.h
@@ -1,0 +1,13 @@
+// HAVE_AS_ARCHEXT_I8MM
+
+#undef HAVE_AS_ARCHEXT_I8MM
+
+/* Assembly feature.
+ * Available in ARMV8 and later.
+ * See: https://developer.arm.com/documentation/101754/0622/armclang-Reference/Other-Compiler-specific-Features/Supported-architecture-features/Matrix-Multiplication-extension?lang=en
+ */
+#if defined(__ARM_ARCH)
+#  if __ARM_ARCH >= 8
+#    define HAVE_AS_ARCHEXT_I8MM 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCH_DIRECTIVE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_ARCH_DIRECTIVE.h
@@ -1,0 +1,10 @@
+// HAVE_AS_ARCH_DIRECTIVE
+
+#undef HAVE_AS_ARCH_DIRECTIVE
+
+/* Assembly directive '.arch'
+ * AFAICS this exists on ARM since very old versions.
+ */
+#if defined(__ARM_ARCH)
+#  define HAVE_AS_ARCH_DIRECTIVE 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_DN_DIRECTIVE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_DN_DIRECTIVE.h
@@ -1,0 +1,14 @@
+// HAVE_AS_DN_DIRECTIVE
+
+#undef HAVE_AS_DN_DIRECTIVE
+
+/* Assembly feature.
+ * Available in ARMv8 and later.
+ * See: https://sourceware.org/binutils/docs/as/ARM-Directives.html
+ * Note: Apple Silicon (M1 and later) uses ARMv8 architecture but has different preprocessor macros.
+ */
+#if (defined(__ARM_NEON) || defined(__ARM_ARCH_ISA_A64)) || (defined(__APPLE__) && (defined(__arm64__) || defined(__arm64e__)))
+#  if defined(__ARM_ARCH) && __ARM_ARCH >= 8 || (defined(__APPLE__) && (defined(__arm64__) || defined(__arm64e__)))
+#    define HAVE_AS_DN_DIRECTIVE 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_FPU_DIRECTIVE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_FPU_DIRECTIVE.h
@@ -1,0 +1,14 @@
+// HAVE_AS_FPU_DIRECTIVE
+
+#undef HAVE_AS_FPU_DIRECTIVE
+
+/* Assembly feature.
+ * Available in ARMv8 and later.
+ * See: https://sourceware.org/binutils/docs/as/ARM-Directives.html
+ * Note: Apple Silicon (M1 and later) uses ARMv8 architecture but has different preprocessor macros.
+ */
+#if defined(__ARM_ARCH) || (defined(__APPLE__) && (defined(__arm64__) || defined(__arm64e__)))
+#  if defined(__ARM_ARCH) && __ARM_ARCH >= 8 || (defined(__APPLE__) && (defined(__arm64__) || defined(__arm64e__)))
+#    define HAVE_AS_FPU_DIRECTIVE 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_FUNC_DIRECTIVE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_FUNC_DIRECTIVE.h
@@ -1,0 +1,11 @@
+// HAVE_AS_FUNC_DIRECTIVE
+
+#undef HAVE_AS_FUNC_DIRECTIVE
+
+/* Assembly directive '.func'/'.function'
+ * AFAICS this exists on ARM since very old versions,
+ * but not on Apple Silicon.
+ */
+#if defined(__ARM_ARCH) && !defined(__APPLE__)
+#  define HAVE_AS_FUNC_DIRECTIVE 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_OBJECT_ARCH_DIRECTIVE.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AS_OBJECT_ARCH_DIRECTIVE.h
@@ -1,0 +1,10 @@
+// HAVE_AS_OBJECT_ARCH_DIRECTIVE
+
+#undef HAVE_AS_OBJECT_ARCH_DIRECTIVE
+
+/* Assembly directive '.object_arch'
+ * AFAICS this exists on ARM since very old versions.
+ */
+#if defined(__ARM_ARCH)
+#  define HAVE_AS_OBJECT_ARCH_DIRECTIVE 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AVX512.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AVX512.h
@@ -1,0 +1,22 @@
+// HAVE_AVX512
+
+#undef HAVE_AVX512
+
+/* GCC, Clang: -march={knl,skylake-avx512, ...}
+ *
+ * MSVC: /arch:AVX512
+ *
+ * This code is based on
+ * * https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-1/additional-predefined-macros.html
+ * * https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
+ */
+
+#if defined(__AVX512CD__) || \
+    defined(__AVX512ER__) || \
+    defined(__AVX512F__)  || \
+    defined(__AVX512PF__) || \
+    defined(__AVX512BW__) || \
+    defined(__AVX512DQ__) || \
+    defined(__AVX512VL__)
+#  define HAVE_AVX512 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AVX512ICL.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_AVX512ICL.h
@@ -1,0 +1,15 @@
+// HAVE_AVX512ICL
+
+#undef HAVE_AVX512ICL
+
+/* GCC, Clang: -m={avx512vbmi, avx512vbmi2, avx512vnni, avx512bf16, avx512fp16}
+ *
+ * MSVC: /arch:AVX512
+ *
+ * Note: This refers to additional AVX-512 extensions that were introduced starting with Ice Lake (ICL)
+ */
+
+#if defined(__AVX512VBMI__) || \
+    defined(__AVX512VNNI__)
+#  define HAVE_AVX512ICL 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_DCBZL.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_DCBZL.h
@@ -1,0 +1,9 @@
+// HAVE_DCBZL
+
+#undef HAVE_DCBZL
+
+/* Since PowerPC 603 processor (mid-1990s).
+ */
+#if defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+#  define HAVE_DCBZL 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ERF.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_ERF.h
@@ -1,0 +1,17 @@
+// HAVE_ERF : BUILD2_AUTOCONF_LIBC_VERSION
+
+#undef HAVE_ERF
+
+/* Since C99, POSIX.1-2001, 4.3BSD,
+ * OpenBSD 2.1, FreeBSD 1.0, NetBSD 1.3, glibc 2.19, Windows, Solaris
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 19)     || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(1, 0)  || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(199105) || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 3) || \
+    BUILD2_AUTOCONF_MACOS_PREREQ(10, 0) || \
+    defined(_WIN32) || \
+    defined(__MINGW32__) || \
+    ((defined(__sun) && defined(__SVR4)) || defined(__sun__))
+#  define HAVE_ERF 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_CLZ.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_CLZ.h
@@ -1,0 +1,35 @@
+// HAVE_FAST_CLZ : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_FAST_CLZ
+
+/* System has optimized support for Count Leading Zeros (CLZ) instructions.
+ * Most modern architectures provide hardware instructions for fast CLZ operations
+ * when targeting 64-bit.
+ * Since glibc 2.3, FreeBSD 5.0, OpenBSD, NetBSD, MacOS 10.6, Solaris,
+ * Windows, MinGW 3.0
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 3)    || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(5, 0)  || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(199610) || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 0) || \
+    BUILD2_AUTOCONF_MACOS_PREREQ(10, 6) || \
+    defined(_WIN32) || \
+    defined(__MINGW32__) || \
+    defined(__CYGWIN__) || \
+    ((defined(__sun) && defined(__SVR4)) || defined(__sun__))
+#  if defined(_WIN64) \
+      || defined(__x86_64__) || defined(__x86_64) \
+      || defined(__ppc64__) || defined(__PPC64__) \
+      || defined(__aarch64__) \
+      || defined(__mips64__) \
+      || defined(__powerpc64__) \
+      || defined(__s390x__) \
+      || (defined(__sparc__) && defined(__arch64__)) \
+      || defined(__riscv_xlen) && __riscv_xlen == 64
+#    define HAVE_FAST_CLZ 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_CMOV.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FAST_CMOV.h
@@ -1,0 +1,25 @@
+// HAVE_FAST_CMOV : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_FAST_CMOV
+
+/* System has optimized support for Count Leading Zeros (CLZ) instructions.
+ * Most modern architectures provide hardware instructions for fast CLZ operations
+ * when targeting 64-bit.
+ * Since glibc 2.0, FreeBSD 5.0, OpenBSD (x86), NetBSD, MacOS 10.6 (x86_64), Solaris (x86_64 + GCC),
+ * Windows, MinGW 3.0
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 3)    || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(5, 0)  || \
+    (BUILD2_AUTOCONF_OPENBSD_PREREQ(199610) && defined(__i386__)) || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(1, 0) || \
+    (BUILD2_AUTOCONF_MACOS_PREREQ(10, 6) && defined(__x86_64__)) || \
+    defined(_WIN32) || \
+    defined(__MINGW32__) || \
+    defined(__CYGWIN__) || \
+    (((defined(__sun) && defined(__SVR4)) || defined(__sun__)) && defined(__x86_64__) && defined (__GNUC__))
+#  define HAVE_FAST_CMOV 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FMA3.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FMA3.h
@@ -1,0 +1,12 @@
+// HAVE_FMA3
+
+#undef HAVE_FMA3
+
+/* GCC, Clang: -mfma
+ *
+ * MSVC: /arch:AVX2
+ */
+#if defined(__FMA__) || \
+    (defined(_WIN32) && defined(__AVX2__))
+#  define HAVE_FMA3 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FMA4.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_FMA4.h
@@ -1,0 +1,12 @@
+// HAVE_FMA4
+
+#undef HAVE_FMA4
+
+/* GCC, Clang: -mfma4
+ *
+ * MSVC: /arch:AVX2
+ */
+#if defined(__FMA4__) || \
+    (defined(_WIN32) && defined(__AVX2__))
+#  define HAVE_FMA4 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_I686.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_I686.h
@@ -1,0 +1,10 @@
+// HAVE_I686
+
+#undef HAVE_I686
+
+/* Defined for i686 processors (Pentium Pro and later)
+ * MSVC: Check for 32-bit x86 (_M_IX86) and compatible instruction sets.
+ */
+#if defined(__i686__) || (defined(_MSC_VER) && defined(_M_IX86) && _M_IX86 >= 600)
+#  define HAVE_I686 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_I8MM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_I8MM.h
@@ -1,0 +1,10 @@
+// HAVE_I8MM
+
+#undef HAVE_I8MM
+
+/* Signals that the target platform supports the I8MM instructions.
+ * __AMX_INT8__: This macro is defined if the compiler supports AMX-INT8 instructions.
+ */
+#if defined(__AMX_INT8__)
+#  define HAVE_I8MM 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LASX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LASX.h
@@ -1,0 +1,14 @@
+// HAVE_LASX
+
+#undef HAVE_LASX
+
+/* GCC, Clang: -mlasx (https://gcc.gnu.org/onlinedocs/gcc/LoongArch-Options.html)
+ * Supported on LoongArch (https://github.com/loongson/la-toolchain-conventions?tab=readme-ov-file#cc-preprocessor-built-in-macro-definitions)
+ */
+#ifdef __loongarch_asx
+#  define HAVE_LASX 1
+// LASX implies LSX
+#  ifndef HAVE_LSX
+#    define HAVE_LSX 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LDBRX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LDBRX.h
@@ -1,0 +1,10 @@
+// HAVE_LDBRX
+
+#undef HAVE_LDBRX
+
+/* Load Doubleword Byte-Reversed Indexed instruction,
+ * which is specific to the PowerPC (PPC) architecture.
+ */
+#if defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__powerpc64__) || defined(__PPC64__)
+#  define HAVE_LDBRX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LINUX_DMA_BUF_H.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LINUX_DMA_BUF_H.h
@@ -1,0 +1,14 @@
+// HAVE_LINUX_DMA_BUF_H
+
+#undef HAVE_LINUX_DMA_BUF_H
+
+/* Presence of the linux/dma-buf.h header, which provides DMA-BUF
+ * support for buffer sharing between different devices in Linux.
+ * Linux (kernel 3.3)
+ */
+#ifdef __linux__
+#  include <linux/version.h>
+#  if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,0)
+#    define HAVE_LINUX_DMA_BUF_H 1
+#  endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOONGSON2.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOONGSON2.h
@@ -1,0 +1,11 @@
+// HAVE_LOONGSON2
+
+#undef HAVE_LOONGSON2
+
+/* MIPS-based Loongson processor.
+ */
+#ifdef __loongson__
+    #if defined(__loongson2f__) || defined(__loongson2e__)
+        #define HAVE_LOONGSON2 1
+    #endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOONGSON3.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LOONGSON3.h
@@ -1,0 +1,11 @@
+// HAVE_LOONGSON3
+
+#undef HAVE_LOONGSON3
+
+/* MIPS-based Loongson processor.
+ */
+#ifdef __loongson__
+    #if defined(__loongson3__)
+        #define HAVE_LOONGSON3 1
+    #endif
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LSX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_LSX.h
@@ -1,0 +1,10 @@
+// HAVE_LSX
+
+#undef HAVE_LSX
+
+/* GCC, Clang: -mlsx (https://gcc.gnu.org/onlinedocs/gcc/LoongArch-Options.html)
+ * Supported on LoongArch (https://github.com/loongson/la-toolchain-conventions?tab=readme-ov-file#cc-preprocessor-built-in-macro-definitions)
+ */
+#ifdef __loongarch_sx
+#  define HAVE_LSX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMI.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMI.h
@@ -1,0 +1,11 @@
+// HAVE_MMI
+
+#undef HAVE_MMI
+
+/* Presence of MMI (Multimedia Instructions), typically used in specific
+ * CPU architectures for multimedia processing, like in certain MIPS processors.
+ * Linux
+ */
+#if defined(__mips__)
+#  define HAVE_MMI 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMX.h
@@ -1,0 +1,12 @@
+// HAVE_MMX : HAVE_X86ASM
+
+#undef HAVE_MMX
+
+/* Presence of MMX instructions:
+ * - Checks for explicit __MMX__ definition first
+ * - Falls back to compiler-specific checks for likely MMX support
+ */
+#if defined(__MMX__) || \
+    defined(HAVE_X86ASM)
+#  define HAVE_MMX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMXEXT.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MMXEXT.h
@@ -1,0 +1,14 @@
+// HAVE_MMXEXT
+
+#undef HAVE_MMXEXT
+
+/* Presence of MMXEXT instructions, which are extensions to the original
+ * MMX instruction set, available on AMD processors starting from K6-2.
+ * Since glibc 2.0 (x86), FreeBSD (x86), OpenBSD (x86), NetBSD (x86),
+ * macOS 10.4 (x86), MSVC
+ */
+#if defined(__MMXEXT__) || \
+    (defined(__i386__) || defined(__x86_64__)) || \
+    (defined(_M_IX86) || defined(_M_X64))
+#  define HAVE_MMXEXT 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MM_EMPTY.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MM_EMPTY.h
@@ -1,0 +1,11 @@
+// HAVE_MM_EMPTY
+
+#undef HAVE_MM_EMPTY
+
+/* Presence of the _mm_empty() function (from <mmintrin.h>), associated
+ * with MMX technology, specifically multimedia extensions found in
+ * x86 architecture systems.
+ */
+#if defined(__MMX__)
+#  define HAVE_MM_EMPTY 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MSA.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_MSA.h
@@ -1,0 +1,10 @@
+// HAVE_MSA
+
+#undef HAVE_MSA
+
+/* Presence of MIPS SIMD Architecture (MSA), which
+ * provides SIMD instructions for MIPS processors.
+ */
+#if defined(__mips_msa)
+#  define HAVE_MSA 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_PPC4XX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_PPC4XX.h
@@ -1,0 +1,10 @@
+// HAVE_PPC4XX
+
+#undef HAVE_PPC4XX
+
+/* Presence of PowerPC 4xx processors,
+ * typically found in embedded systems.
+ */
+#if defined(__powerpc__) && defined(__PPC4XX__)
+#  define HAVE_PPC4XX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RDTSC.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RDTSC.h
@@ -1,0 +1,12 @@
+// HAVE_RDTSC
+
+#undef HAVE_RDTSC
+
+/* Check for the presence of the RDTSC (Read Time-Stamp Counter) instruction,
+ * which reads the number of CPU cycles since the last reset.
+ * Available on x86 (32-bit and 64-bit) processors.
+ */
+#if defined(__i386__) || defined(__x86_64__) || \
+    defined(_M_IX86) || defined(_M_X64)
+#  define HAVE_RDTSC 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RV.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RV.h
@@ -1,0 +1,9 @@
+// HAVE_RV
+
+#undef HAVE_RV
+
+/* Presence of RISC-V architecture (RV) support in the environment.
+ */
+#if defined(__riscv__) || defined(__riscv)
+#  define HAVE_RV 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RVV.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_RVV.h
@@ -1,0 +1,10 @@
+// HAVE_RVV
+
+#undef HAVE_RVV
+
+/* Presence of RISC-V Vector Extension (RVV), which adds vector
+ * processing capabilities to the base RISC-V architecture.
+ */
+#if defined(__riscv_vector)
+#  define HAVE_RVV 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SECTION_DATA_REL_RO.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SECTION_DATA_REL_RO.h
@@ -1,0 +1,19 @@
+// HAVE_SECTION_DATA_REL_RO : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_SECTION_DATA_REL_RO
+
+/* Presence of the .data.rel.ro section, which is used for
+ * placing read-only data that may be relocated at runtime.
+ * Since glibc 2.3, FreeBSD 7.0, Solaris 10
+ */
+#if BUILD2_AUTOCONF_GLIBC_PREREQ(2, 3)    || \
+    BUILD2_AUTOCONF_OPENBSD_PREREQ(201609) || \
+    BUILD2_AUTOCONF_FREEBSD_PREREQ(7, 0)   || \
+    BUILD2_AUTOCONF_NETBSD_PREREQ(7, 0)    || \
+    ((defined(__sun) && defined(__SVR4)) || defined(__sun__))
+#  define HAVE_SECTION_DATA_REL_RO 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_16.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_16.h
@@ -1,0 +1,12 @@
+// HAVE_SIMD_ALIGN_16
+
+#undef HAVE_SIMD_ALIGN_16
+
+/* Presence of 16-byte SIMD alignment,
+ * typically required for SSE and NEON.
+ * WIN32: Check for _M_IX86 or _M_X64 and SSE support.
+ */
+#if defined(__SSE__) || defined(__ARM_NEON) || defined(__ARM_NEON__) || \
+    (defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64)))
+#  define HAVE_SIMD_ALIGN_16 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_32.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_32.h
@@ -1,0 +1,9 @@
+// HAVE_SIMD_ALIGN_32
+
+#undef HAVE_SIMD_ALIGN_32
+
+/* Presence of 32-byte SIMD alignment, required for AVX.
+ */
+#if defined(__AVX__)
+#  define HAVE_SIMD_ALIGN_32 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_64.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SIMD_ALIGN_64.h
@@ -1,0 +1,9 @@
+// HAVE_SIMD_ALIGN_64
+
+#undef HAVE_SIMD_ALIGN_64
+
+/* Presence of 64-byte SIMD alignment, required for AVX-512.
+ */
+#if defined(__AVX512F__)
+#  define HAVE_SIMD_ALIGN_64 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SSE4.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_SSE4.h
@@ -1,0 +1,16 @@
+// HAVE_SSE4
+
+#undef HAVE_SSE4
+
+/* Presence of SSE4 (Streaming SIMD Extensions 4)
+ * instructions, which include SSE4.1 and SSE4.2.
+ * This code is based on HAVE_SSE4_1 and:
+ * https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qsimd.h.
+ */
+#ifdef _MSC_VER
+#  ifdef __AVX__
+#    define HAVE_SSE4 1
+#  endif
+#elif defined(__SSE4_1__) || defined(__SSE4_2__)
+#  define HAVE_SSE4 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFP.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFP.h
@@ -1,0 +1,10 @@
+// HAVE_VFP
+
+#undef HAVE_VFP
+
+/* Presence of Vector Floating Point (VFP), which is an extension
+ * for ARM processors providing floating-point arithmetic instructions.
+ */
+#ifdef __ARM_VFP__
+#  define HAVE_VFP 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFPV3.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFPV3.h
@@ -1,0 +1,9 @@
+// HAVE_VFPV3
+
+#undef HAVE_VFPV3
+
+/* Presence of VFP v3 on ARM platforms.
+ */
+#if defined(__VFP_FP__) && defined(__ARM_ARCH_7A__)
+#  define HAVE_VFPV3 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFP_ARGS.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VFP_ARGS.h
@@ -1,0 +1,10 @@
+// HAVE_VFP_ARGS
+
+#undef HAVE_VFP_ARGS
+
+/* If the system passes arguments to functions using
+ * VFP (Vector Floating Point) registers, common on ARM systems.
+ */
+#ifdef __ARM_PCS_VFP
+#  define HAVE_VFP_ARGS 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VSX.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_VSX.h
@@ -1,0 +1,10 @@
+// HAVE_VSX
+
+#undef HAVE_VSX
+
+/* Presence of Vector Scalar Extension (VSX) support, an extension to
+ * the PowerPC architecture that enhances SIMD and floating-point operations.
+ */
+#ifdef __VSX__
+#  define HAVE_VSX 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_X86ASM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_X86ASM.h
@@ -1,0 +1,12 @@
+// HAVE_X86ASM
+
+#undef HAVE_X86ASM
+
+/* Presence of x86 assembly support, ensuring that the system can
+ * execute inline assembly or external assembly for x86 processors.
+ */
+#if defined(__i386__) || \
+    defined(__x86_64__) || \
+    (defined(_M_IX86) || defined(_M_X64)) && (defined(_MSC_VER) || defined(__GNUC__) || defined(__clang__))
+#  define HAVE_X86ASM 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_XFORM_ASM.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_XFORM_ASM.h
@@ -1,0 +1,10 @@
+// HAVE_XFORM_ASM
+
+#undef HAVE_XFORM_ASM
+
+/* Presence of transformation-related assembly optimizations,
+ * typically for image or video processing tasks.
+ */
+#ifdef __XFORM_ASM__
+#  define HAVE_XFORM_ASM 1
+#endif

--- a/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_XMM_CLOBBERS.h
+++ b/libbuild2-autoconf/libbuild2/autoconf/checks/HAVE_XMM_CLOBBERS.h
@@ -1,0 +1,26 @@
+// HAVE_XMM_CLOBBERS : BUILD2_AUTOCONF_LIBC_VERSION
+
+#ifndef BUILD2_AUTOCONF_LIBC_VERSION
+#  error BUILD2_AUTOCONF_LIBC_VERSION appears to be conditionally included
+#endif
+
+#undef HAVE_XMM_CLOBBERS
+
+/* Checks whether the system allows for the use of XMM registers (used in SSE)
+ * to be clobbered by inline assembly instructions. It ensures that the
+ * compiler knows which registers are being modified.
+ * Since Linux, FreeBSD, OpenBSD, NetBSD, MacOS 10.6, Solaris,
+ * Windows, MinGW
+ */
+#if defined(__linux__)                  || \
+    defined(__FreeBSD__)                || \
+    defined(__OpenBSD__)                || \
+    defined(__NetBSD__)                 || \
+    defined(__MINGW32__)                || \
+    defined(__CYGWIN__)                 || \
+    (defined(__sun) && defined(__SVR4)) || \
+    BUILD2_AUTOCONF_MACOS_PREREQ(10, 6)
+#  if defined(__SSE__) && defined(__x86_64__)
+#    define HAVE_XMM_CLOBBERS 1
+#  endif
+#endif


### PR DESCRIPTION
Co-author: @francoisk 

These checks are from the [`FFmpeg` project catalog](https://github.com/build2-packaging/FFmpeg/tree/main/libavutil/build/autoconf/checks) as well as from [`NASM`](https://github.com/build2-packaging/nasm/tree/main/nasm/build/autoconf/checks), currently building on (mainly) Linux/BSD & Windows/Mingw (CI).